### PR TITLE
add a second nuget package as the name is reserved on nuget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         run: dotnet nuget add source https://nuget.pkg.github.com/logandavies181/index.json --name GitHub --username logandavies181 --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
-        run: dotnet nuget push .\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate
+        run: dotnet nuget push .\XFCCSharp*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate
         shell: pwsh
 
   push-nuget:
@@ -81,7 +81,7 @@ jobs:
     if: github.event_name == 'release'
     environment:
       name: "NuGet"
-      url: https://www.nuget.org/packages/XFCCSharp
+      url: https://www.nuget.org/packages/XForwardedClientCert
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
@@ -90,7 +90,7 @@ jobs:
           name: "windows-latest"
       - name: "Dotnet NuGet Push"
         run: |
-          Get-ChildItem .\ -Filter *.nupkg |
+          Get-ChildItem .\ -Filter XForwardedClientCert*.nupkg |
           Where-Object { !$_.Name.Contains('preview') } |
           ForEach-Object { dotnet nuget push $_ --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key ${{secrets.NUGET_API_KEY}} }
         shell: pwsh

--- a/Source/XFCCSharp/XForwardedClientCert.csproj
+++ b/Source/XFCCSharp/XForwardedClientCert.csproj
@@ -1,0 +1,1 @@
+XFCCSharp.csproj

--- a/XFCCSharp.sln
+++ b/XFCCSharp.sln
@@ -53,6 +53,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{0555
 		.github\SECURITY.md = .github\SECURITY.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XForwardedClientCert", "Source\XFCCSharp\XForwardedClientCert.csproj", "{5A92A89D-1443-44DB-A15F-74F08AC24CEA}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XFCCSharp", "Source\XFCCSharp\XFCCSharp.csproj", "{5A92A89D-1443-44DB-A15F-74F08AC24CEA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XFCCSharp.Test", "Tests\XFCCSharp.Test\XFCCSharp.Test.csproj", "{C02A4049-D22D-4F72-B60E-4D9D85C2C62B}"


### PR DESCRIPTION
<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/logandavies181/XFCCSharp/blob/main/.github/CONTRIBUTING.md
-->

There was an XFCC package on Nuget already. I guess that was blocking the name there